### PR TITLE
perf: add `cache` to `lib/registry/get-next-data > getData.XXX`

### DIFF
--- a/next-app/src/lib/registry/get-next-data.ts
+++ b/next-app/src/lib/registry/get-next-data.ts
@@ -8,38 +8,42 @@ import { generateStaticSidebarData, type StaticSidebarData } from '#root/registr
 //  input
 
 const getData = {
-  registryForNext: async () => {
-    if (APP_DATA_MODE === 'compute') {
-      return await generateStaticRegistryForNext();
+  registryForNext: cache(
+    async () => {
+      if (APP_DATA_MODE === 'compute') {
+        return await generateStaticRegistryForNext();
+      }
+      if (APP_DATA_MODE === 'static') {
+        // NOTE: 
+        // Webpack/Turbopack, before the build process, statically anaylze every import, also dynamic `import()`, and :
+        // - IF THE PATH IS A SINGLE STRING, like `'path/to/file'`, it check if file exists
+        //   This lead to the error: "Cannot find module '#root/registry/output/static-registry.for-next-app.json'" if the file is not present.
+        // - IF THE PATH IS A CONCAT STRING, like `'path/to' + 'file'`, it skips the check
+        // So we "fake" the path to be dynamic splitting the string in two part (forcing resolution at build time).
+        const path = '#root/registry/output/' + 'static-registry.for-next-app.json';
+        return await import(path).then((m) => m.default as RegistryForNext);
+      }
+      throw new Error(`Invalid APP_DATA_MODE: ${APP_DATA_MODE}`);
     }
-    if (APP_DATA_MODE === 'static') {
-      // NOTE: 
-      // Webpack/Turbopack, before the build process, statically anaylze every import, also dynamic `import()`, and :
-      // - IF THE PATH IS A SINGLE STRING, like `'path/to/file'`, it check if file exists
-      //   This lead to the error: "Cannot find module '#root/registry/output/static-registry.for-next-app.json'" if the file is not present.
-      // - IF THE PATH IS A CONCAT STRING, like `'path/to' + 'file'`, it skips the check
-      // So we "fake" the path to be dynamic splitting the string in two part (forcing resolution at build time).
-      const path = '#root/registry/output/' + 'static-registry.for-next-app.json';
-      return await import(path).then((m) => m.default as RegistryForNext);
+  ),
+  sidebarData: cache(
+    async () => {
+      if (APP_DATA_MODE === 'compute') {
+        return await generateStaticSidebarData();
+      }
+      if (APP_DATA_MODE === 'static') {
+        // NOTE: 
+        // Webpack/Turbopack, before the build process, statically anaylze every import, also dynamic `import()`, and :
+        // - IF THE PATH IS A SINGLE STRING, like `'path/to/file'`, it check if file exists
+        //   This lead to the error: "Cannot find module '#root/registry/output/static-sidebar-data.json'" if the file is not present.
+        // - IF THE PATH IS A CONCAT STRING, like `'path/to' + 'file'`, it skips the check
+        // So we "fake" the path to be dynamic splitting the string in two part (forcing resolution at build time).
+        const path = '#root/registry/output/' + 'static-sidebar-data.json';
+        return await import(path).then((m) => m.default as StaticSidebarData);
+      }
+      throw new Error(`Invalid APP_DATA_MODE: ${APP_DATA_MODE}`);
     }
-    throw new Error(`Invalid APP_DATA_MODE: ${APP_DATA_MODE}`);
-  },
-  sidebarData: async () => {
-    if (APP_DATA_MODE === 'compute') {
-      return await generateStaticSidebarData();
-    }
-    if (APP_DATA_MODE === 'static') {
-      // NOTE: 
-      // Webpack/Turbopack, before the build process, statically anaylze every import, also dynamic `import()`, and :
-      // - IF THE PATH IS A SINGLE STRING, like `'path/to/file'`, it check if file exists
-      //   This lead to the error: "Cannot find module '#root/registry/output/static-sidebar-data.json'" if the file is not present.
-      // - IF THE PATH IS A CONCAT STRING, like `'path/to' + 'file'`, it skips the check
-      // So we "fake" the path to be dynamic splitting the string in two part (forcing resolution at build time).
-      const path = '#root/registry/output/' + 'static-sidebar-data.json';
-      return await import(path).then((m) => m.default as StaticSidebarData);
-    }
-    throw new Error(`Invalid APP_DATA_MODE: ${APP_DATA_MODE}`);
-  },
+  ),
 };
 
 


### PR DESCRIPTION
Fixes #1


## Problem

Glossary:
- `getDataFn`: method of the `getData` object, that return a "fixed" data that doesn't change.
- `deriverFn`: a function that internally calls a `getDataFn` (like `getSidebarData`)

Now `cache` is used in `deriverFn` function, but not on `getDataFn`.
Some of these `deriverFn` functions are without arguments, some have arguments.

I think that:
- in case of `deriverFn` with no arguments, the `cache` on deriver is enough to do not recompute `getData`
- but in case of `deriverFn` with arguments (like `getRegistryItemByName`) `getDataFn` is recomputed with no reason, slowing the build  (especially in dev)

## Changes

- added `cache` as wrapper of `getDataFn`
